### PR TITLE
Do not require credentials to be env vars, allow auto setup

### DIFF
--- a/cmd/terraform-registry/main.go
+++ b/cmd/terraform-registry/main.go
@@ -116,8 +116,6 @@ func main() {
 	// Load environment variables here!
 	gitHubToken = os.Getenv("GITHUB_TOKEN")
 
-	awsAccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
-	awsSecretAccessKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
 	awsRegion = os.Getenv("AWS_REGION")
 	awsS3Bucket = os.Getenv("AWS_S3_BUCKET")
 
@@ -269,12 +267,6 @@ func gitHubRegistry(reg *registry.Registry) {
 
 // s3Registry configures the registry to use S3Store.
 func s3Registry(reg *registry.Registry) {
-	if awsAccessKeyID == "" {
-		logger.Fatal("missing environment variable 'AWS_ACCESS_KEY_ID'")
-	}
-	if awsSecretAccessKey == "" {
-		logger.Fatal("missing environment variable 'AWS_SECRET_ACCESS_KEY'")
-	}
 	if awsRegion == "" {
 		logger.Fatal("missing environment variable 'AWS_REGION'")
 	}


### PR DESCRIPTION
I'm able to read from a bucket using AWS default credentials this way.

```
$ echo "a" aws s3 cp - s3://matador-terraform-026745160685/v1/modules/platform/foo/bar/versions
$ make build && AWS_REGION=us-east-1 AWS_S3_BUCKET=matador-terraform-026745160685 ./terraform-registry -store s3 -auth-disabled -log-level debug  &
$ curl http://localhost:8080/v1/modules/platform/foo/bar/versions
2023/08/21 14:34:50 "GET http://localhost:8080/v1/modules/platform/foo/bar/versions HTTP/1.1" from 127.0.0.1:62497 - 200 31B in 462.073101ms
{"modules":[{"versions":null}]}%
```